### PR TITLE
fix updating job configs of existing jobs

### DIFF
--- a/src/JenkinsApi/Item/Job.php
+++ b/src/JenkinsApi/Item/Job.php
@@ -196,7 +196,7 @@ class Job extends AbstractItem
     }
 
     /**
-     * @param string|array $configuration
+     * @param string $configuration config XML
      *
      */
     public function setJobConfig($configuration)

--- a/src/JenkinsApi/Item/Job.php
+++ b/src/JenkinsApi/Item/Job.php
@@ -202,7 +202,7 @@ class Job extends AbstractItem
     public function setJobConfig($configuration)
     {
         $return = $this->getJenkins()->post(sprintf('job/%s/config.xml', $this->_jobName), $configuration, array(CURLOPT_HTTPHEADER => array('Content-Type: text/xml')));
-        if ($return) {
+        if ($return != 1) {
             throw new RuntimeException(sprintf('Error during setting configuration for job %s', $this->_jobName));
         }
     }

--- a/src/JenkinsApi/Jenkins.php
+++ b/src/JenkinsApi/Jenkins.php
@@ -172,13 +172,13 @@ class Jenkins
 
     /**
      * @param string $url
-     * @param array  $parameters
+     * @param array|string  $parameters
      * @param array  $curlOpts
      *
      * @throws RuntimeException
      * @return bool
      */
-    public function post($url, array $parameters = [], array $curlOpts = [])
+    public function post($url, $parameters = [], array $curlOpts = [])
     {
         $url = sprintf('%s', $this->_baseUrl) . $url;
 
@@ -187,7 +187,10 @@ class Jenkins
             curl_setopt_array($curl, $curlOpts);
         }
         curl_setopt($curl, CURLOPT_POST, 1);
-        curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query($parameters));
+        if(is_array($parameters)) {
+            $parameters = http_build_query($parameters);
+        }
+        curl_setopt($curl, CURLOPT_POSTFIELDS,$parameters);
 
         $headers = (isset($curlOpts[CURLOPT_HTTPHEADER])) ? $curlOpts[CURLOPT_HTTPHEADER] : array();
 


### PR DESCRIPTION
Following code:

``` php
        if($job = $jenkins->getJob($jobName)) {
            $job->setJobConfig($jobConfig);
        }
```
- Resulted in an Error "Argument 2 passed to JenkinsApi\Jenkins::post() must be of the type array, string given"
- The Jenkins API returns a 1 on successful updates, so an exception was triggered.
