### PR TITLE
Support folder job names (names containing "/")

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 vendor/
-composer.phar
 composer.lock
-composer.local.json
-composer.local.lock
 .idea
 tests/

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@productsupcom/engineering

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,6 @@
     {
       "name": "Christopher Biel",
       "email": "christopher.biel89@gmail.com"
-    },
-    {
-      "name": "Werner Spiegel",
-      "email": "ws@productsup.com"
     }
   ],
   "require": {

--- a/src/JenkinsApi/AbstractItem.php
+++ b/src/JenkinsApi/AbstractItem.php
@@ -42,6 +42,16 @@ abstract class AbstractItem
     }
 
     /**
+     * @param string $jobName
+     *
+     * @return string
+     */
+    protected function getUrlEncodedJobName(string $jobName)
+    {
+        return str_replace('%2F', '/', rawurlencode($jobName));
+    }
+
+    /**
      * @return string
      */
     abstract protected function getUrl();

--- a/src/JenkinsApi/Exceptions/BuildNotFoundException.php
+++ b/src/JenkinsApi/Exceptions/BuildNotFoundException.php
@@ -4,7 +4,7 @@ namespace JenkinsApi\Exceptions;
 
 class BuildNotFoundException extends JenkinsApiException
 {
-    public function __construct($buildNumber, $jobName, $code = 0, \Exception $previous = null)
+    public function __construct($buildNumber, $jobName, $code = 404, \Exception $previous = null)
     {
         parent::__construct(sprintf("Build %u of Job '%s' not found", $buildNumber, $jobName), $code, $previous);
     }

--- a/src/JenkinsApi/Exceptions/BuildNotFoundException.php
+++ b/src/JenkinsApi/Exceptions/BuildNotFoundException.php
@@ -4,7 +4,7 @@ namespace JenkinsApi\Exceptions;
 
 class BuildNotFoundException extends JenkinsApiException
 {
-    public function __construct($buildNumber, $jobName, $code = 0, \Exception $previous)
+    public function __construct($buildNumber, $jobName, $code = 0, \Exception $previous = null)
     {
         parent::__construct(sprintf("Build %u of Job '%s' not found", $buildNumber, $jobName), $code, $previous);
     }

--- a/src/JenkinsApi/Exceptions/JobNotFoundException.php
+++ b/src/JenkinsApi/Exceptions/JobNotFoundException.php
@@ -4,7 +4,7 @@ namespace JenkinsApi\Exceptions;
 
 class JobNotFoundException extends JenkinsApiException
 {
-    public function __construct($jobname, $code = 0, \Exception $previous = null)
+    public function __construct($jobname, $code = 404, \Exception $previous = null)
     {
         parent::__construct(sprintf("Job '%s' not found", $jobname), $code, $previous);
     }

--- a/src/JenkinsApi/Exceptions/JobNotFoundException.php
+++ b/src/JenkinsApi/Exceptions/JobNotFoundException.php
@@ -4,7 +4,7 @@ namespace JenkinsApi\Exceptions;
 
 class JobNotFoundException extends JenkinsApiException
 {
-    public function __construct($jobname, $code = 0, \Exception $previous)
+    public function __construct($jobname, $code = 0, \Exception $previous = null)
     {
         parent::__construct(sprintf("Job '%s' not found", $jobname), $code, $previous);
     }

--- a/src/JenkinsApi/Exceptions/NodeNotFoundException.php
+++ b/src/JenkinsApi/Exceptions/NodeNotFoundException.php
@@ -4,7 +4,7 @@ namespace JenkinsApi\Exceptions;
 
 class NodeNotFoundException extends JenkinsApiException
 {
-    public function __construct($nodeName, $code = 0, \Exception $previous = null)
+    public function __construct($nodeName, $code = 404, \Exception $previous = null)
     {
         parent::__construct(sprintf("Node '%s' not found", $nodeName), $code, $previous);
     }

--- a/src/JenkinsApi/Exceptions/NodeNotFoundException.php
+++ b/src/JenkinsApi/Exceptions/NodeNotFoundException.php
@@ -4,7 +4,7 @@ namespace JenkinsApi\Exceptions;
 
 class NodeNotFoundException extends JenkinsApiException
 {
-    public function __construct($nodeName, $code = 0, \Exception $previous)
+    public function __construct($nodeName, $code = 0, \Exception $previous = null)
     {
         parent::__construct(sprintf("Node '%s' not found", $nodeName), $code, $previous);
     }

--- a/src/JenkinsApi/Item/Build.php
+++ b/src/JenkinsApi/Item/Build.php
@@ -77,7 +77,7 @@ class Build extends AbstractItem
         try {
             return parent::refresh();
         } catch (JenkinsApiException $e) {
-            throw new BuildNotFoundException($this->_buildNumber, $this->_jobName, 0, $e);
+            throw new BuildNotFoundException($this->_buildNumber, $this->_jobName, 404, $e);
         }
     }
 

--- a/src/JenkinsApi/Item/Build.php
+++ b/src/JenkinsApi/Item/Build.php
@@ -86,7 +86,7 @@ class Build extends AbstractItem
      */
     protected function getUrl()
     {
-        return sprintf('job/%s/%d/api/json', rawurlencode($this->_jobName), rawurlencode($this->_buildNumber));
+        return sprintf('job/%s/%d/api/json', $this->getUrlEncodedJobName($this->_jobName), rawurlencode($this->_buildNumber));
     }
 
     /**

--- a/src/JenkinsApi/Item/Job.php
+++ b/src/JenkinsApi/Item/Job.php
@@ -40,7 +40,7 @@ class Job extends AbstractItem
         try {
             return parent::refresh();
         } catch (JenkinsApiException $e) {
-            throw new JobNotFoundException($this->_jobName, 0, $e);
+            throw new JobNotFoundException($this->_jobName, 404, $e);
         }
     }
 

--- a/src/JenkinsApi/Item/Job.php
+++ b/src/JenkinsApi/Item/Job.php
@@ -49,7 +49,7 @@ class Job extends AbstractItem
      */
     protected function getUrl()
     {
-        return sprintf('job/%s/api/json', rawurlencode($this->_jobName));
+        return sprintf('job/%s/api/json', $this->getUrlEncodedJobName($this->_jobName));
     }
 
     /**
@@ -73,7 +73,7 @@ class Job extends AbstractItem
      */
     public function getBuild($buildId)
     {
-        return $this->_jenkins->getBuild($this->getName(), $buildId);
+        return $this->_jenkins->getBuild($this->_jobName, $buildId);
     }
 
     /**
@@ -120,7 +120,7 @@ class Job extends AbstractItem
         if (null === $this->_data->lastBuild) {
             return null;
         }
-        return $this->_jenkins->getBuild($this->getName(), $this->_data->lastBuild->number);
+        return $this->_jenkins->getBuild($this->_jobName, $this->_data->lastBuild->number);
     }
 
     /**
@@ -143,9 +143,9 @@ class Job extends AbstractItem
     public function launch($parameters = array())
     {
         if (empty($parameters)) {
-            return $this->_jenkins->post(sprintf('job/%s/build', rawurlencode($this->_jobName)));
+            return $this->_jenkins->post(sprintf('job/%s/build', $this->getUrlEncodedJobName($this->_jobName)));
         } else {
-            return $this->_jenkins->post(sprintf('job/%s/buildWithParameters', rawurlencode($this->_jobName)), $parameters);
+            return $this->_jenkins->post(sprintf('job/%s/buildWithParameters', $this->getUrlEncodedJobName($this->_jobName)), $parameters);
         }
     }
 

--- a/src/JenkinsApi/Item/LastBuild.php
+++ b/src/JenkinsApi/Item/LastBuild.php
@@ -35,6 +35,6 @@ class LastBuild extends Build
      */
     protected function getUrl()
     {
-        return sprintf('job/%s/lastBuild/api/json', rawurlencode($this->_jobName));
+        return sprintf('job/%s/lastBuild/api/json', $this->getUrlEncodedJobName($this->_jobName));
     }
 }

--- a/src/JenkinsApi/Item/Node.php
+++ b/src/JenkinsApi/Item/Node.php
@@ -45,7 +45,7 @@ class Node extends AbstractItem
         try {
             return parent::refresh();
         } catch (JenkinsApiException $e) {
-            throw new NodeNotFoundException($this->_nodeName, 0, $e);
+            throw new NodeNotFoundException($this->_nodeName, 404, $e);
         }
     }
 

--- a/src/JenkinsApi/Item/View.php
+++ b/src/JenkinsApi/Item/View.php
@@ -36,7 +36,7 @@ class View extends AbstractItem
      */
     protected function getUrl()
     {
-        return sprintf('view/%s/api/json', rawurlencode($this->_name));
+        return sprintf('view/%s/api/json', $this->getUrlEncodedJobName($this->_name));
     }
 
     /**

--- a/src/JenkinsApi/Jenkins.php
+++ b/src/JenkinsApi/Jenkins.php
@@ -155,7 +155,6 @@ class Jenkins
      */
     public function get($url, $depth = 1, $params = array(), array $curlOpts = [], $raw = false)
     {
-//        $url = str_replace(' ', '%20', sprintf('%s' . $url . '?depth=' . $depth, $this->_baseUrl));
         $url = sprintf('%s', $this->_baseUrl) . $url . '?depth=' . $depth;
         if ($params) {
             foreach ($params as $key => $val) {


### PR DESCRIPTION
Folder job names that contain special characters are URL encoded. However, this breaks job names that are folders (i.e names that contain "/").

A job "foo/bar" becomes "foo%2Fbar" which doesn't exist.

This PR adds support for folder job names.